### PR TITLE
Change default scope to DeclScope

### DIFF
--- a/cmd/godot/main.go
+++ b/cmd/godot/main.go
@@ -20,7 +20,7 @@ var version = "master"
 const defaultConfigFile = "config.yaml"
 
 var defaultSettings = godot.Settings{
-	Scope:   godot.TopLevelScope,
+	Scope:   godot.DeclScope,
 	Period:  true,
 	Capital: false,
 }


### PR DESCRIPTION
The `README` says the default scope is `declarations` but the code currently sets it to `toplevel`.

So one or the other needs to be adjusted so they are in-sync.

We have hit a bunch of false positives with `toplevel` and so would prefer to keep the default at `declarations`.

Especially since it's painful to change just that setting as it requires a config file since it's not possible to pass in a dict/map of custom settings as a CLI arg:
https://github.com/tetafro/godot/issues/17