### PR TITLE
Add etc. to list of handled abbreviations

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -19,7 +19,7 @@ var (
 	lastChars = []string{".", "?", "!", ".)", "?)", "!)", specialReplacer}
 
 	// Abbreviations to exclude from capital letters check.
-	abbreviations = []string{"i.e.", "i. e.", "e.g.", "e. g."}
+	abbreviations = []string{"i.e.", "i. e.", "e.g.", "e. g.", "etc."}
 
 	// Special tags in comments like "// nolint:", or "// +k8s:".
 	tags = regexp.MustCompile(`^\+?[a-z0-9]+:`)

--- a/checks_test.go
+++ b/checks_test.go
@@ -182,7 +182,7 @@ func TestCheckCapital(t *testing.T) {
 		},
 		{
 			name:      "sentence with abbreviations",
-			text:      "One two, i.e. hello, world, e.g. e. g. word",
+			text:      "One two, i.e. hello, world, e.g. e. g. word and etc. word",
 			skipFirst: false,
 			issues:    nil,
 		},


### PR DESCRIPTION
xref: https://github.com/tetafro/godot/issues/21#issuecomment-895844894


Not sure if there are other frequently used ways to spell `etc.`

/cc @tetafro 