### PR TITLE
Update links to use go.dev instead of outdated golang.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Linter that checks if all top-level comments contain a period at the
 end of the last sentence if needed.
 
-[CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences) quote:
+[CodeReviewComments](https://go.dev/wiki/CodeReviewComments#comment-sentences) quote:
 
 > Comments should begin with the name of the thing being described
 > and end in a period

--- a/checks.go
+++ b/checks.go
@@ -239,7 +239,7 @@ func isSpecialBlock(comment string) bool {
 // isSpecialLine checks that given comment line is special and
 // shouldn't be checked as a regular sentence.
 func isSpecialLine(comment string) bool {
-	// Skip cgo export tags: https://golang.org/cmd/cgo/#hdr-C_references_to_Go
+	// Skip cgo export tags: https://pkg.go.dev/cmd/cgo#hdr-C_references_to_Go
 	if strings.HasPrefix(comment, "//export ") {
 		return true
 	}


### PR DESCRIPTION
The PR updates the links in the docs:
- replace the old `golang.org/cmd/cgo` with the new `pkg.go.dev/cmd/cgo`;
- replace deprecated `github.com/golang/go/wiki` with `go.dev/wiki`.