### PR TITLE
fix: panic due incorrect issue's position column resolution in checkCapital

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -171,7 +171,7 @@ func checkCapital(c comment) []Issue {
 		if state == endOfSentence && unicode.IsLower(r) {
 			pp = append(pp, position{
 				line:   pos.line,
-				column: runeToByteColumn(c.text, pos.column),
+				column: runeToByteColumn(c.lines[pos.line-1], pos.column),
 			})
 		}
 		state = empty

--- a/checks_test.go
+++ b/checks_test.go
@@ -338,6 +338,17 @@ func TestCheckCapital(t *testing.T) {
 			},
 		},
 		{
+			name: "issue position column resolved from correct line",
+			comment: comment{
+				lines: []string{"// Кириллица.", "// Issue. here."},
+				text:  " Кириллица.\n Issue. here.",
+				start: start,
+			},
+			issues: []Issue{
+				{Pos: token.Position{Line: 2, Column: 11}},
+			},
+		},
+		{
 			name: "sentence with leading spaces",
 			comment: comment{
 				lines: []string{"//    hello, world"},


### PR DESCRIPTION
## Bug
The entire text is used to resolve the column for the issue in `checkCapital`. This leads to incorrect issue's position resolution when the first part of the text consists of 2-byte runes and the line with the issue consists of 1-byte runes. 

A panic "slice bounds out of range" occurs if the length of the issue line is less than the resolved column.

The test case demonstrates it.

## Fix

Use the current line to resolve the column for the issue in `checkCapital`.