### PR TITLE
Bump `gopkg.in/yaml` to v3

### DIFF
--- a/cmd/godot/main.go
+++ b/cmd/godot/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/tetafro/godot"
-	yaml "gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v3"
 )
 
 // version is the application version. It is set to the latest git tag in CI.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/tetafro/godot
 
 go 1.22
 
-require gopkg.in/yaml.v2 v2.4.0
+require go.yaml.in/yaml/v3 v3.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
This bumps [`gopkg.in/yaml`](https://pkg.go.dev/gopkg.in/yaml) from v2 to v3.

Also, I wanted to make you aware of the fact that this particular YAML parser has been deprecated/archived (see [`go-yaml/yaml`](https://github.com/go-yaml/yaml)) and I believe a suitable (drop-in, probably long-term) alternative is [`go.yaml.in/yaml`](https://pkg.go.dev/go.yaml.in/yaml). If you want I can update this Pull Request to switch to the alternative instead.